### PR TITLE
Fix deposits

### DIFF
--- a/cbproorder/interface/coinbase_deposit_service.py
+++ b/cbproorder/interface/coinbase_deposit_service.py
@@ -86,7 +86,7 @@ class CoinbaseDepositService(DepositService):
             amount=str(amount),
             currency=self._USD_CURRENCY,
         )
-        deposit = deposit_response["data"]
+        deposit = deposit_response["transfer"]
         logger.info("Deposit created", extra={"deposit": deposit})
         result = DepositResult.from_deposit_dict(deposit)
         logger.info("Deposit result", extra={"result": result})
@@ -162,6 +162,7 @@ class CoinbaseDepositService(DepositService):
             "amount": amount,
             "currency": currency,
             "payment_method": payment_method,
+            "commit": True,
         }
 
         return self.advanced_client.post(url_path=endpoint, data=data, **kwargs)

--- a/tests/interface/test_coinbase_deposit_service.py
+++ b/tests/interface/test_coinbase_deposit_service.py
@@ -56,7 +56,7 @@ class TestCoinbaseDepositService(unittest.TestCase):
         mock_get_deposit.return_value = "79774f73-3838-4505-8db6-d0a7421f3dc7"
         mock_get_payment_method_id.return_value = "738e6a58-10a1-4a89-a64b-7057d5cecf27"
         client.post.return_value = {
-            "data": {
+            "transfer": {
                 "id": "67e0eaec-07d7-54c4-a72c-2e92826897df",
                 "status": "created",
                 "payment_method": {
@@ -106,6 +106,7 @@ class TestCoinbaseDepositService(unittest.TestCase):
                 "amount": str(amount),
                 "currency": service._USD_CURRENCY,
                 "payment_method": "738e6a58-10a1-4a89-a64b-7057d5cecf27",
+                "commit": True,
             },
         )
         self.assertEqual(deposit.status, "created")


### PR DESCRIPTION
## Description

Fixes the failed deposits by changing the expected response from the Coinbase v2 API, which now references a `transfer` object instead of a `data` object, and it also now forcefully requires the `commit` option to be set to `true`. None of these changes are reflected on their documentation, which still shows the old approach.

## Testing

Was able to perform deposits with this change.